### PR TITLE
fix: misplaced awaits resulting in wrong tests

### DIFF
--- a/test/Web3Task.test.ts
+++ b/test/Web3Task.test.ts
@@ -65,7 +65,7 @@ describe("Web3Task", function () {
 			true
 		);
 
-		expect(
+		await expect(
 			await Web3Task.connect(owner).withdraw(
 				leaderId,
 				ethers.utils.parseEther("0.1")
@@ -76,13 +76,13 @@ describe("Web3Task", function () {
 	});
 
 	it("should create new authorizations { leader, member }", async function () {
-		expect(await Web3Task.setRole(leaderId, userA.address, true))
+		await expect(await Web3Task.setRole(leaderId, userA.address, true))
 			.to.emit(Web3Task, "AuthorizePersonnel")
 			.withArgs(leaderId, userA.address, true);
-		expect(await Web3Task.setRole(leaderId, userB.address, true))
+		await expect(await Web3Task.setRole(leaderId, userB.address, true))
 			.to.emit(Web3Task, "AuthorizePersonnel")
 			.withArgs(leaderId, userB.address, true);
-		expect(await Web3Task.setRole(memberId, userC.address, true))
+		await expect(await Web3Task.setRole(memberId, userC.address, true))
 			.to.emit(Web3Task, "AuthorizePersonnel")
 			.withArgs(memberId, userC.address, true);
 	});
@@ -108,7 +108,7 @@ describe("Web3Task", function () {
 
 	it("should create new operator { createTask }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("createTask");
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
 		expect(await Web3Task.isOperator(interfaceId, leaderId)).to.be.equal(true);
@@ -124,10 +124,10 @@ describe("Web3Task", function () {
 
 	it("should create new operator { reviewTask }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("reviewTask");
-		expect(await Web3Task.setOperator(interfaceId, memberId, true))
+		await expect(await Web3Task.setOperator(interfaceId, memberId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, memberId, true);
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
 		expect(await Web3Task.isOperator(interfaceId, memberId)).to.be.equal(true);
@@ -136,7 +136,7 @@ describe("Web3Task", function () {
 
 	it("should create new operator { completeTask }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("completeTask");
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
 		expect(await Web3Task.isOperator(interfaceId, leaderId)).to.be.equal(true);
@@ -144,15 +144,17 @@ describe("Web3Task", function () {
 
 	it("should create new operator { cancelTask }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("cancelTask");
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
+
 		expect(await Web3Task.isOperator(interfaceId, leaderId)).to.be.equal(true);
 	});
 
 	it("should create new operator { setTitle }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("setTitle");
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
 		expect(await Web3Task.isOperator(interfaceId, leaderId)).to.be.equal(true);
@@ -160,7 +162,7 @@ describe("Web3Task", function () {
 
 	it("should create new operator { setDescription }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("setDescription");
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
 		expect(await Web3Task.isOperator(interfaceId, leaderId)).to.be.equal(true);
@@ -168,7 +170,7 @@ describe("Web3Task", function () {
 
 	it("should create new operator { setEndDate }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("setEndDate");
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
 		expect(await Web3Task.isOperator(interfaceId, leaderId)).to.be.equal(true);
@@ -176,7 +178,7 @@ describe("Web3Task", function () {
 
 	it("should create new operator { setMetadata }", async function () {
 		let interfaceId = Web3Task.interface.getSighash("setMetadata");
-		expect(await Web3Task.setOperator(interfaceId, leaderId, true))
+		await expect(await Web3Task.setOperator(interfaceId, leaderId, true))
 			.to.emit(Web3Task, "AuthorizeOperator")
 			.withArgs(interfaceId, leaderId, true);
 		expect(await Web3Task.isOperator(interfaceId, leaderId)).to.be.equal(true);
@@ -287,7 +289,9 @@ describe("Web3Task", function () {
 	});
 
 	it("should set title", async function () {
-		expect(await Web3Task.connect(userA).setTitle(createdTaskId, taskTitle))
+		await expect(
+			await Web3Task.connect(userA).setTitle(createdTaskId, taskTitle)
+		)
 			.to.emit(Web3Task, "TitleUpdated")
 			.withArgs(createdTaskId, taskTitle);
 		const task = await Web3Task.getTask(createdTaskId);
@@ -295,13 +299,13 @@ describe("Web3Task", function () {
 	});
 
 	it("should set description", async function () {
-		expect(
+		await expect(
 			await Web3Task.connect(userA).setDescription(
 				createdTaskId,
 				taskDescription
 			)
 		)
-			.to.emit(Web3Task, "TitleUpdated")
+			.to.emit(Web3Task, "DescriptionUpdated")
 			.withArgs(createdTaskId, taskDescription);
 		const task = await Web3Task.getTask(createdTaskId);
 		expect(task.description).to.equal(taskDescription);
@@ -309,23 +313,29 @@ describe("Web3Task", function () {
 
 	it("should set endDate", async function () {
 		const targetDate = Math.floor(Date.now() / 1000) + 3600;
-		expect(await Web3Task.connect(userA).setEndDate(createdTaskId, targetDate))
-			.to.emit(Web3Task, "TitleUpdated")
+		await expect(
+			await Web3Task.connect(userA).setEndDate(createdTaskId, targetDate)
+		)
+			.to.emit(Web3Task, "EndDateUpdated")
 			.withArgs(createdTaskId, targetDate);
 		const task = await Web3Task.getTask(createdTaskId);
 		expect(task.endDate).to.equal(targetDate);
 	});
 
 	it("should set metadata", async function () {
-		expect(await Web3Task.connect(userA).setTitle(createdTaskId, taskTitle))
+		await expect(
+			await Web3Task.connect(userA).setMetadata(createdTaskId, "newMeta")
+		)
 			.to.emit(Web3Task, "MetadataUpdated")
-			.withArgs(createdTaskId, taskTitle);
+			.withArgs(createdTaskId, "newMeta");
 		const task = await Web3Task.getTask(createdTaskId);
-		expect(task.title).to.equal(taskTitle);
+		expect(task.metadata).to.equal("newMeta");
 	});
 
 	it("should start task", async function () {
-		expect(await Web3Task.connect(userC).startTask(createdTaskId, memberId))
+		await expect(
+			await Web3Task.connect(userC).startTask(createdTaskId, memberId)
+		)
 			.to.emit(Web3Task, "TaskStarted")
 			.withArgs(createdTaskId, userC.address);
 		const task = await Web3Task.getTask(createdTaskId);
@@ -333,31 +343,32 @@ describe("Web3Task", function () {
 	});
 
 	it("should review task", async function () {
+		const mockData = "ipfs link";
 		const task2 = await Web3Task.getTask(createdTaskId);
 		expect(task2.assignee == userC.address).to.equal(true);
-		expect(
+		await expect(
 			await Web3Task.connect(userC).reviewTask(
 				createdTaskId,
 				memberId,
-				"ipfs link"
+				mockData
 			)
 		)
-			.to.emit(Web3Task, "TaskUpdated")
-			.withArgs(createdTaskId, Status.Review);
+			.to.emit(Web3Task, "TaskReviewed")
+			.withArgs(createdTaskId, userC.address, mockData);
 
 		// Leaders can also call review to place a note during
 		// the task review process. This is supposed to ping pong
 		// between the leader and the assignee until the task is
 		// completed.
-		expect(
+		await expect(
 			await Web3Task.connect(userB).reviewTask(
 				createdTaskId,
 				leaderId,
-				"ipfs link"
+				mockData
 			)
 		)
-			.to.emit(Web3Task, "TaskUpdated")
-			.withArgs(createdTaskId, Status.Review);
+			.to.emit(Web3Task, "TaskReviewed")
+			.withArgs(createdTaskId, userB.address, mockData);
 
 		const task = await Web3Task.getTask(createdTaskId);
 		expect(task.status).to.equal(Status.Review);
@@ -366,7 +377,9 @@ describe("Web3Task", function () {
 	it("should complete task ", async function () {
 		expect(await Web3Task.connect(userA).completeTask(createdTaskId, leaderId))
 			.to.be.ok;
-		expect(await Web3Task.connect(userB).completeTask(createdTaskId, leaderId))
+		await expect(
+			await Web3Task.connect(userB).completeTask(createdTaskId, leaderId)
+		)
 			.to.emit(Web3Task, "TaskUpdated")
 			.withArgs(createdTaskId, Status.Completed);
 
@@ -375,12 +388,18 @@ describe("Web3Task", function () {
 	});
 
 	it("should cancel task", async function () {
-		expect(await Web3Task.connect(userA).cancelTask(createdTaskId, leaderId))
+		await expect(
+			await Web3Task.connect(userA).cancelTask(createdTaskId, leaderId)
+		)
 			.to.emit(Web3Task, "TaskUpdated")
 			.withArgs(createdTaskId, Status.Canceled);
 	});
 
 	it("should set title failure", async function () {
+		const test = await Web3Task.getTask(createdTaskId);
+		console.log(test);
+		console.log(createdTaskId);
+		console.log(Status.Canceled);
 		await expect(Web3Task.connect(userA).setTitle(createdTaskId, taskTitle))
 			.to.be.revertedWithCustomError(Web3Task, "TaskCannotBeChanged")
 			.withArgs(createdTaskId, Status.Canceled);


### PR DESCRIPTION
- double await on expect (inside and outside) when verifying event emissions
- single await inside the expect when verifying arguments from custom errors

closes #6 