### PR TITLE
feat: already voted expansion with quorum, better score set

### DIFF
--- a/contracts/interfaces/IWeb3Task.sol
+++ b/contracts/interfaces/IWeb3Task.sol
@@ -266,6 +266,15 @@ interface IWeb3Task {
     function getScore(address addr) external view returns (uint256);
 
     /**
+     * @dev This function returns a boolean if the `addr` has voted for
+     * a specific task.
+     */
+    function hasVoted(
+        uint256 taskId,
+        address addr
+    ) external view returns (bool);
+
+    /**
      * @dev This function allows to deposit funds into the contract into
      * a specific authorization role.
      *

--- a/scripts/createTasks.ts
+++ b/scripts/createTasks.ts
@@ -27,7 +27,7 @@ async function main() {
 			endDate: currentBlockTimeStamp + 86400,
 			authorizedRoles: [10, 3],
 			creatorRole: 5,
-			assignee: "0xa607c9d1913009356E2Eb97D0c526e7c0A5a86a4",
+			assignee: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
 			metadata:
 				"https://ipfs.io/ipfs/QmY5DnoeR8KvFQbf2swJcSZrBfXo4icnMuzrjGvj6q7CEh",
 		};

--- a/scripts/setRole.ts
+++ b/scripts/setRole.ts
@@ -26,6 +26,16 @@ async function main() {
 			maxFeePerGas: 200000000000,
 		}
 	);
+
+	await contract.setRole(
+		5,
+		"0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+		false,
+		{
+			maxPriorityFeePerGas: 200000000000,
+			maxFeePerGas: 200000000000,
+		}
+	);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
- quorum was increasing but already voted wasn't, it would've conflicted.
- score is now settled at the internal _setScore function and is only callable once.
- updated the address on scripts to be the second address that hardhat provides